### PR TITLE
Safe initalization of libGeoIP

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,4 +1,5 @@
 AM_CPPFLAGS = @VMOD_INCLUDES@
+AM_CFLAGS = -Wall -Wextra -Werror
 
 vmoddir = @VMOD_DIR@
 vmod_LTLIBRARIES = libvmod_geoip.la

--- a/src/tests/test01.vtc
+++ b/src/tests/test01.vtc
@@ -1,4 +1,4 @@
-varnishtest "Test geoip vmod"
+varnishtest "Test an unknown IP address"
 
 server s1 {
 	rxreq
@@ -9,12 +9,14 @@ varnish v1 -vcl+backend {
 	import geoip from "${vmod_topbuild}/src/.libs/libvmod_geoip.so";
 
 	sub vcl_deliver {
-		set resp.http.X-Country-Code = geoip.country_code("85.10.240.255");
+		set resp.http.X-Country-Code = geoip.country_code("127.0.0.1");
+		set resp.http.X-Country-Name = geoip.country_name("127.0.0.1");
 	}
 } -start
 
 client c1 {
 	txreq -url "/"
 	rxresp
-	expect resp.http.X-Country-Code == "DE"
+	expect resp.http.X-Country-Code == Unknown
+	expect resp.http.X-Country-Name == Unknown
 } -run

--- a/src/tests/test01.vtc
+++ b/src/tests/test01.vtc
@@ -11,6 +11,9 @@ varnish v1 -vcl+backend {
 	sub vcl_deliver {
 		set resp.http.X-Country-Code = geoip.country_code("127.0.0.1");
 		set resp.http.X-Country-Name = geoip.country_name("127.0.0.1");
+
+		set resp.http.X-IP-Country-Code = geoip.country_code(client.ip);
+		set resp.http.X-IP-Country-Name = geoip.country_name(client.ip);
 	}
 } -start
 
@@ -19,4 +22,6 @@ client c1 {
 	rxresp
 	expect resp.http.X-Country-Code == Unknown
 	expect resp.http.X-Country-Name == Unknown
+	expect resp.http.X-IP-Country-Code == Unknown
+	expect resp.http.X-IP-Country-Name == Unknown
 } -run

--- a/src/tests/test02.vtc
+++ b/src/tests/test02.vtc
@@ -1,4 +1,4 @@
-varnishtest "Test geoip vmod"
+varnishtest "Test a german IP address"
 
 server s1 {
 	rxreq
@@ -9,6 +9,7 @@ varnish v1 -vcl+backend {
 	import geoip from "${vmod_topbuild}/src/.libs/libvmod_geoip.so";
 
 	sub vcl_deliver {
+		set resp.http.X-Country-Code = geoip.country_code("85.10.240.255");
 		set resp.http.X-Country-Name = geoip.country_name("85.10.240.255");
 	}
 } -start
@@ -16,5 +17,6 @@ varnish v1 -vcl+backend {
 client c1 {
 	txreq -url "/"
 	rxresp
-	expect resp.http.X-Country-Name == "Germany"
+	expect resp.http.X-Country-Code == DE
+	expect resp.http.X-Country-Name == Germany
 } -run

--- a/src/vmod_geoip.c
+++ b/src/vmod_geoip.c
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 #include <GeoIP.h>
 
+#include "vcl.h"
 #include "vrt.h"
 #include "vrt_obj.h"
 #include "cache/cache.h"
@@ -31,14 +32,26 @@ init_priv(struct vmod_priv *pp)
 	GeoIP_set_charset((GeoIP *)pp->priv, GEOIP_CHARSET_UTF8);
 }
 
+int __match_proto__(vmod_event_f)
+vmod_event(VRT_CTX, struct vmod_priv *pp, enum vcl_event_e evt)
+{
+
+	(void)ctx;
+	(void)evt;
+
+	if (!pp->priv)
+		init_priv(pp);
+
+	return (0);
+}
+
 VCL_STRING
 vmod_country_code(const struct vrt_ctx *ctx, struct vmod_priv *pp,
     VCL_STRING ip)
 {
 	const char *country = NULL;
 
-	if (!pp->priv)
-		init_priv(pp);
+	AN(pp->priv);
 
 	if (ip)
 		country = GeoIP_country_code_by_addr((GeoIP *)pp->priv, ip);
@@ -59,8 +72,7 @@ vmod_country_name(const struct vrt_ctx *ctx, struct vmod_priv *pp,
 {
 	const char *country = NULL;
 
-	if (!pp->priv)
-		init_priv(pp);
+	AN(pp->priv);
 
 	if (ip)
 		country = GeoIP_country_name_by_addr((GeoIP *)pp->priv, ip);
@@ -82,8 +94,7 @@ vmod_region_name(const struct vrt_ctx *ctx, struct vmod_priv *pp,
 	GeoIPRegion *gir;
 	const char *region = NULL;
 
-	if (!pp->priv)
-		init_priv(pp);
+	AN(pp->priv);
 
 	if (ip) {
 		if ((gir = GeoIP_region_by_addr((GeoIP *)pp->priv, ip))) {

--- a/src/vmod_geoip.c
+++ b/src/vmod_geoip.c
@@ -3,7 +3,7 @@
  * GeoIP API: http://www.maxmind.com/app/c
  *
  * See file README.rst for usage instructions
- * 
+ *
  * This code is licensed under a MIT-style License, see file LICENSE
 */
 
@@ -20,27 +20,25 @@
 // The default string in case the GeoIP lookup fails
 #define GI_UNKNOWN_STRING "Unknown"
 
-static void
-init_priv(struct vmod_priv *pp)
-{
-	// The README says:
-	// If GEOIP_MMAP_CACHE doesn't work on a 64bit machine, try adding
-	// the flag "MAP_32BIT" to the mmap call. MMAP is not avail for WIN32.
-	pp->priv = GeoIP_new(GEOIP_MMAP_CACHE);
-	AN(pp->priv);
-	pp->free = (vmod_priv_free_f *)GeoIP_delete;
-	GeoIP_set_charset((GeoIP *)pp->priv, GEOIP_CHARSET_UTF8);
-}
-
 int __match_proto__(vmod_event_f)
 vmod_event(VRT_CTX, struct vmod_priv *pp, enum vcl_event_e evt)
 {
 
-	(void)ctx;
-	(void)evt;
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 
-	if (!pp->priv)
-		init_priv(pp);
+	if (pp->priv == NULL) {
+		xxxassert(evt == VCL_EVENT_LOAD);
+
+		/* The README says:
+		 * If GEOIP_MMAP_CACHE doesn't work on a 64bit machine, try
+		 * adding * the flag "MAP_32BIT" to the mmap call. MMAP is not
+		 * avail for WIN32.
+		 */
+		pp->priv = GeoIP_new(GEOIP_MMAP_CACHE);
+		AN(pp->priv);
+		pp->free = (vmod_priv_free_f *)GeoIP_delete;
+		GeoIP_set_charset((GeoIP *)pp->priv, GEOIP_CHARSET_UTF8);
+	}
 
 	return (0);
 }
@@ -51,6 +49,7 @@ vmod_country_code(const struct vrt_ctx *ctx, struct vmod_priv *pp,
 {
 	const char *country = NULL;
 
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	AN(pp->priv);
 
 	if (ip)
@@ -72,6 +71,7 @@ vmod_country_name(const struct vrt_ctx *ctx, struct vmod_priv *pp,
 {
 	const char *country = NULL;
 
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	AN(pp->priv);
 
 	if (ip)
@@ -94,6 +94,7 @@ vmod_region_name(const struct vrt_ctx *ctx, struct vmod_priv *pp,
 	GeoIPRegion *gir;
 	const char *region = NULL;
 
+	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	AN(pp->priv);
 
 	if (ip) {

--- a/src/vmod_geoip.c
+++ b/src/vmod_geoip.c
@@ -70,13 +70,6 @@ vmod_region_name_by_addr(GeoIP *gi, const char *ip)
 		if (str == NULL)					\
 			return ("Unknown");				\
 		return (WS_Copy(ctx->ws, str, -1));			\
-	}								\
-									\
-	VCL_STRING							\
-	vmod_ip_##prop(VRT_CTX, struct vmod_priv *pp, VCL_IP ip)	\
-	{								\
-									\
-		return (vmod_##prop(ctx, pp, VRT_IP_string(ctx, ip)));	\
 	}
 GEOIP_PROPERTY(country_code, GeoIP_country_code_by_addr);
 GEOIP_PROPERTY(country_name, GeoIP_country_name_by_addr);

--- a/src/vmod_geoip.c
+++ b/src/vmod_geoip.c
@@ -87,25 +87,32 @@ vmod_ip_country_name(const struct vrt_ctx *ctx, struct vmod_priv *pp,
 	return (vmod_country_name(ctx, pp, VRT_IP_string(ctx, ip)));
 }
 
+static const char *
+vmod_region_name_by_addr(GeoIP *gi, const char *ip)
+{
+	GeoIPRegion *gir;
+	const char *region = NULL;
+
+	gir = GeoIP_region_by_addr(gi, ip);
+	if (gir == NULL)
+		return (NULL);
+
+	region = GeoIP_region_name_by_code(gir->country_code, gir->region);
+	GeoIPRegion_delete(gir);
+	return (region);
+}
+
 VCL_STRING
 vmod_region_name(const struct vrt_ctx *ctx, struct vmod_priv *pp,
     VCL_STRING ip)
 {
-	GeoIPRegion *gir;
 	const char *region = NULL;
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	AN(pp->priv);
 
-	if (ip) {
-		if ((gir = GeoIP_region_by_addr((GeoIP *)pp->priv, ip))) {
-			region =
-			    GeoIP_region_name_by_code(gir->country_code,
-			    gir->region);
-			// TODO: is gir * a local copy or the actual record?
-			GeoIPRegion_delete(gir);
-		}
-	}
+	if (ip)
+		region = vmod_region_name_by_addr((GeoIP *)pp->priv, ip);
 
 	return (WS_Copy(ctx->ws, (region ? region : GI_UNKNOWN_STRING), -1));
 }

--- a/src/vmod_geoip.c
+++ b/src/vmod_geoip.c
@@ -62,14 +62,13 @@ vmod_region_name_by_addr(GeoIP *gi, const char *ip)
 		const char *str = NULL;					\
 									\
 		CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);			\
-		CHECK_OBJ_NOTNULL(ctx->ws, WS_MAGIC);			\
 		AN(pp->priv);						\
 									\
 		if (ip)							\
 			str = func(pp->priv, ip);			\
 		if (str == NULL)					\
-			return ("Unknown");				\
-		return (WS_Copy(ctx->ws, str, -1));			\
+			str = "Unknown";				\
+		return (str);						\
 	}
 GEOIP_PROPERTY(country_code, GeoIP_country_code_by_addr);
 GEOIP_PROPERTY(country_name, GeoIP_country_name_by_addr);

--- a/src/vmod_geoip.c
+++ b/src/vmod_geoip.c
@@ -17,9 +17,6 @@
 
 #include "vcc_if.h"
 
-// The default string in case the GeoIP lookup fails
-#define GI_UNKNOWN_STRING "Unknown"
-
 int __match_proto__(vmod_event_f)
 vmod_event(VRT_CTX, struct vmod_priv *pp, enum vcl_event_e evt)
 {
@@ -43,50 +40,6 @@ vmod_event(VRT_CTX, struct vmod_priv *pp, enum vcl_event_e evt)
 	return (0);
 }
 
-VCL_STRING
-vmod_country_code(const struct vrt_ctx *ctx, struct vmod_priv *pp,
-    VCL_STRING ip)
-{
-	const char *country = NULL;
-
-	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
-	AN(pp->priv);
-
-	if (ip)
-		country = GeoIP_country_code_by_addr((GeoIP *)pp->priv, ip);
-
-	return (WS_Copy(ctx->ws, (country ? country : GI_UNKNOWN_STRING), -1));
-}
-
-VCL_STRING
-vmod_ip_country_code(const struct vrt_ctx *ctx, struct vmod_priv *pp,
-    VCL_IP ip)
-{
-	return (vmod_country_code(ctx, pp, VRT_IP_string(ctx, ip)));
-}
-
-VCL_STRING
-vmod_country_name(const struct vrt_ctx *ctx, struct vmod_priv *pp,
-    VCL_STRING ip)
-{
-	const char *country = NULL;
-
-	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
-	AN(pp->priv);
-
-	if (ip)
-		country = GeoIP_country_name_by_addr((GeoIP *)pp->priv, ip);
-
-	return (WS_Copy(ctx->ws, (country ? country : GI_UNKNOWN_STRING), -1));
-}
-
-VCL_STRING
-vmod_ip_country_name(const struct vrt_ctx *ctx, struct vmod_priv *pp,
-    VCL_IP ip)
-{
-	return (vmod_country_name(ctx, pp, VRT_IP_string(ctx, ip)));
-}
-
 static const char *
 vmod_region_name_by_addr(GeoIP *gi, const char *ip)
 {
@@ -102,24 +55,30 @@ vmod_region_name_by_addr(GeoIP *gi, const char *ip)
 	return (region);
 }
 
-VCL_STRING
-vmod_region_name(const struct vrt_ctx *ctx, struct vmod_priv *pp,
-    VCL_STRING ip)
-{
-	const char *region = NULL;
-
-	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
-	AN(pp->priv);
-
-	if (ip)
-		region = vmod_region_name_by_addr((GeoIP *)pp->priv, ip);
-
-	return (WS_Copy(ctx->ws, (region ? region : GI_UNKNOWN_STRING), -1));
-}
-
-VCL_STRING
-vmod_ip_region_name(const struct vrt_ctx *ctx, struct vmod_priv *pp,
-    VCL_IP ip)
-{
-	return (vmod_region_name(ctx, pp, VRT_IP_string(ctx, ip)));
-}
+#define GEOIP_PROPERTY(prop, func)					\
+	VCL_STRING							\
+	vmod_##prop(VRT_CTX, struct vmod_priv *pp, VCL_STRING ip)	\
+	{								\
+		const char *str = NULL;					\
+									\
+		CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);			\
+		CHECK_OBJ_NOTNULL(ctx->ws, WS_MAGIC);			\
+		AN(pp->priv);						\
+									\
+		if (ip)							\
+			str = func(pp->priv, ip);			\
+		if (str == NULL)					\
+			return ("Unknown");				\
+		return (WS_Copy(ctx->ws, str, -1));			\
+	}								\
+									\
+	VCL_STRING							\
+	vmod_ip_##prop(VRT_CTX, struct vmod_priv *pp, VCL_IP ip)	\
+	{								\
+									\
+		return (vmod_##prop(ctx, pp, VRT_IP_string(ctx, ip)));	\
+	}
+GEOIP_PROPERTY(country_code, GeoIP_country_code_by_addr);
+GEOIP_PROPERTY(country_name, GeoIP_country_name_by_addr);
+GEOIP_PROPERTY(region_name, vmod_region_name_by_addr);
+#undef GEOIP_PROPERTY

--- a/src/vmod_geoip.vcc
+++ b/src/vmod_geoip.vcc
@@ -4,12 +4,9 @@ $Event vmod_event
 
 ## look up two-letter country codes
 $Function STRING country_code(PRIV_VCL, STRING)
-#$Function STRING ip_country_code(PRIV_VCL, IP)
 
 ## look up (english) country names
 $Function STRING country_name(PRIV_VCL, STRING)
-#$Function STRING ip_country_name(PRIV_VCL, IP)
 
 ## look up (english) region names
 #$Function STRING region_name(PRIV_VCL, STRING)
-##$Function STRING ip_region_name(PRIV_VCL, IP)

--- a/src/vmod_geoip.vcc
+++ b/src/vmod_geoip.vcc
@@ -1,5 +1,7 @@
 $Module geoip 3
 
+$Event vmod_event
+
 ## look up two-letter country codes
 $Function STRING country_code(PRIV_VCL, STRING)
 #$Function STRING ip_country_code(PRIV_VCL, IP)


### PR DESCRIPTION
Initially reported by @carlosabalde, there's an unsafe (and hidden) unguarded initialization in the code that can result in a segmentation fault when ran concurrently.

This pull request fixes the race by forcing the initialization on the CLI thread, and also tackles code duplication.

I have create a 4.0 branch from the current master, this work is 4.1+ only.
